### PR TITLE
fix: pick random ports if not specified

### DIFF
--- a/amqp_mock/_mock_server.py
+++ b/amqp_mock/_mock_server.py
@@ -49,14 +49,17 @@ class AmqpMockServer:
                                 host=self._http_server.host,
                                 port=self._http_server.port)
         await http_site.start()
+        self._http_server.port = self._http_runner.addresses[0][1]
 
         self._amqp_runner = AmqpRunner(self._amqp_server)
         await self._amqp_runner.setup()
 
         amqp_site = AmqpSite(self._amqp_runner,
                              host=self._amqp_server.host,
-                             port=self._amqp_server.port)
+                             port=self._amqp_server.port or None)
         await amqp_site.start()
+
+        self._amqp_server.port = amqp_site.port
 
     async def stop(self) -> None:
         if self._http_runner:

--- a/amqp_mock/amqp_server/_amqp_server.py
+++ b/amqp_mock/amqp_server/_amqp_server.py
@@ -41,11 +41,11 @@ class AmqpServer:
         return self._host
 
     @property
-    def port(self) -> int:
+    def port(self) -> Optional[int]:
         return self._port
 
     @port.setter
-    def port(self, value):
+    def port(self, value: int) -> None:
         self._port = value
 
     async def _on_publish(self, message: Message) -> None:

--- a/amqp_mock/amqp_server/_amqp_server.py
+++ b/amqp_mock/amqp_server/_amqp_server.py
@@ -10,7 +10,7 @@ __all__ = ("AmqpServer",)
 
 
 class AmqpServer:
-    def __init__(self, storage: Storage, host: str = "0.0.0.0", port: int = 5672,
+    def __init__(self, storage: Storage, host: str = "0.0.0.0", port: Optional[int] = None,
                  server_properties: Optional[Dict[str, Any]] = None) -> None:
         self._storage = storage
         self._host = host
@@ -43,6 +43,10 @@ class AmqpServer:
     @property
     def port(self) -> int:
         return self._port
+
+    @port.setter
+    def port(self, value):
+        self._port = value
 
     async def _on_publish(self, message: Message) -> None:
         try:

--- a/amqp_mock/amqp_server/_amqp_site.py
+++ b/amqp_mock/amqp_server/_amqp_site.py
@@ -15,10 +15,15 @@ class AmqpSite(BaseSite):
         self._host = host
         self._port = port
 
+    @property
+    def port(self):
+        return self._port
+
     async def start(self) -> None:
         await super().start()
         callback = cast(Callable[[StreamReader, StreamWriter], Any], self._runner.server)
         self._server = await start_server(callback, host=self._host, port=self._port)
+        self._port = self._server.sockets[0].getsockname()[1]
 
     def name(self) -> str:
         return "ampq://{host}:{port}".format(host=self._host, port=self._port)

--- a/amqp_mock/amqp_server/_amqp_site.py
+++ b/amqp_mock/amqp_server/_amqp_site.py
@@ -1,6 +1,6 @@
 from asyncio import start_server
 from asyncio.streams import StreamReader, StreamWriter
-from typing import Any, Callable, cast
+from typing import Any, Callable, cast, Optional
 
 from aiohttp.web import BaseSite
 
@@ -10,20 +10,21 @@ __all__ = ("AmqpSite",)
 
 
 class AmqpSite(BaseSite):
-    def __init__(self, runner: AmqpRunner, *, host: str, port: int):
+    def __init__(self, runner: AmqpRunner, *, host: str, port: Optional[int]):
         super().__init__(runner)
         self._host = host
         self._port = port
 
     @property
-    def port(self):
+    def port(self) -> Optional[int]:
         return self._port
 
     async def start(self) -> None:
         await super().start()
         callback = cast(Callable[[StreamReader, StreamWriter], Any], self._runner.server)
         self._server = await start_server(callback, host=self._host, port=self._port)
-        self._port = self._server.sockets[0].getsockname()[1]
+        if self._server.sockets is not None and len(self._server.sockets) > 0:
+            self._port = self._server.sockets[0].getsockname()[1]
 
     def name(self) -> str:
         return "ampq://{host}:{port}".format(host=self._host, port=self._port)

--- a/amqp_mock/http_server/_http_server.py
+++ b/amqp_mock/http_server/_http_server.py
@@ -9,7 +9,7 @@ __all__ = ("HttpServer",)
 
 
 class HttpServer:
-    def __init__(self, storage: Storage, host: str = "0.0.0.0", port: int = 80) -> None:
+    def __init__(self, storage: Storage, host: str = "0.0.0.0", port: int = 0) -> None:
         self._storage = storage
         self._host = host
         self._port = port
@@ -21,6 +21,10 @@ class HttpServer:
     @property
     def port(self) -> int:
         return self._port
+
+    @port.setter
+    def port(self, port: int):
+        self._port = port
 
     @route("GET", "/healthcheck")
     async def healthcheck(self, request: web.Request) -> web.Response:

--- a/amqp_mock/http_server/_http_server.py
+++ b/amqp_mock/http_server/_http_server.py
@@ -23,7 +23,7 @@ class HttpServer:
         return self._port
 
     @port.setter
-    def port(self, port: int):
+    def port(self, port: int) -> None:
         self._port = port
 
     @route("GET", "/healthcheck")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.2
+current_version = 0.2.0
 message = bump version → {new_version}
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def find_dev_required():
 
 setup(
     name="amqp-mock",
-    version="0.1.2",
+    version="0.2.0",
     description="Remote AMQP mock",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -28,6 +28,26 @@ async def test_async_context_manager():
 
 
 @pytest.mark.asyncio
+async def test_async_context_manager_rand():
+    with given:
+        storage = Storage()
+        http_server = HttpServer(storage)
+        amqp_server = AmqpServer(storage)
+        queue = "test_queue"
+
+    async with given:
+        async with create_amqp_mock(http_server, amqp_server) as mock:
+            async with AmqpClient(amqp_server.host, amqp_server.port) as amqp_client:
+                with when:
+                    await mock.client.publish_message(queue, Message("text"))
+
+                with then:
+                    await amqp_client.consume(queue)
+                    messages = await amqp_client.wait_for(message_count=1)
+                    assert len(messages) == 1
+
+
+@pytest.mark.asyncio
 async def test_sync_context_manager():
     with given:
         storage = Storage()


### PR DESCRIPTION
This resolves #1

For HTTP, AMQP server, if not specified, pick a free
port from the system on listen.