### PR TITLE
allow consumer to keep running when published messages are exhausted

### DIFF
--- a/amqp_mock/_storage.py
+++ b/amqp_mock/_storage.py
@@ -1,3 +1,4 @@
+from asyncio import Queue
 from collections import OrderedDict
 from typing import AsyncGenerator, Dict, List
 
@@ -7,7 +8,7 @@ from ._message import Message, MessageStatus, QueuedMessage
 class Storage:
     def __init__(self) -> None:
         self._exchanges: Dict[str, List[Message]] = {}
-        self._queues: Dict[str, List[Message]] = {}
+        self._queues: Dict[str, Queue[Message]] = {}
         self._history: Dict[str, QueuedMessage] = OrderedDict()
 
     async def clear(self) -> None:
@@ -31,8 +32,8 @@ class Storage:
 
     async def add_message_to_queue(self, queue: str, message: Message) -> None:
         if queue not in self._queues:
-            self._queues[queue] = []
-        self._queues[queue].insert(0, message)
+            self._queues[queue] = Queue()
+        await self._queues[queue].put(message)
         self._history[message.id] = QueuedMessage(message, queue)
 
     async def get_history(self) -> List[QueuedMessage]:
@@ -44,6 +45,6 @@ class Storage:
     async def get_next_message(self, queue: str) -> AsyncGenerator[Message, None]:
         if queue not in self._queues:
             return
-        while len(self._queues[queue]) > 0:
-            message = self._queues[queue].pop()
-            yield message
+
+        while True:
+            yield await self._queues[queue].get()


### PR DESCRIPTION
Previously, a consumer task would simply end if there are no more
messages on the queue being consumed.  This is counter to the
expectation that a consumer will keep running and consume new messages
that appear on the queue.

For simple tests this expectation can be ignored by pre-loading the
queue with a few messages, seeing if they're consumed, then exit the
test.  But for testing more complicated interactions where a consumer
might need to wait for messages from a publisher this won't work.

I believe this maintains the simplicity of previous use cases, except
that `Storage.get_next_message()` is never exhausted, and can block.

To this end it's also necessary (when it wasn't previously) to ensure
that all consumer tasks associated with a connection are cancelled when
closing that connection.

This has a small merge conflict with #6, but it's easily resolved (I'm trying to
keep each of these PRs independent).