### PR TITLE
allow binding a queue to an exchange

### DIFF
--- a/amqp_mock/_storage.py
+++ b/amqp_mock/_storage.py
@@ -1,6 +1,6 @@
 from asyncio import Queue
-from collections import OrderedDict
-from typing import AsyncGenerator, Dict, List
+from collections import defaultdict, OrderedDict
+from typing import AsyncGenerator, DefaultDict, Dict, List
 
 from ._message import Message, MessageStatus, QueuedMessage
 
@@ -10,16 +10,28 @@ class Storage:
         self._exchanges: Dict[str, List[Message]] = {}
         self._queues: Dict[str, Queue[Message]] = {}
         self._history: Dict[str, QueuedMessage] = OrderedDict()
+        self._binds: DefaultDict[str, Dict[str, str]] = defaultdict(dict)
 
     async def clear(self) -> None:
         self._exchanges = {}
         self._queues = {}
         self._history = OrderedDict()
+        self._binds = defaultdict(dict)
 
     async def add_message_to_exchange(self, exchange: str, message: Message) -> None:
         if exchange not in self._exchanges:
             self._exchanges[exchange] = []
         self._exchanges[exchange].insert(0, message)
+
+        binds = self._binds.get(exchange)
+        routing_key = message.routing_key
+
+        if binds and routing_key in binds:
+            await self.add_message_to_queue(binds[routing_key], message)
+
+    async def bind_queue_to_exchange(self, queue: str, exchange: str,
+                                     routing_key: str = "") -> None:
+        self._binds[exchange][routing_key] = queue
 
     async def get_messages_from_exchange(self, exchange: str) -> List[Message]:
         if exchange not in self._exchanges:

--- a/amqp_mock/_storage.py
+++ b/amqp_mock/_storage.py
@@ -33,6 +33,12 @@ class Storage:
                                      routing_key: str = "") -> None:
         self._binds[exchange][routing_key] = queue
 
+    async def declare_queue(self, queue: str) -> None:
+        if queue not in self._queues:
+            self._queues[queue] = Queue()
+
+        await self.bind_queue_to_exchange(queue, "", routing_key=queue)
+
     async def get_messages_from_exchange(self, exchange: str) -> List[Message]:
         if exchange not in self._exchanges:
             return []
@@ -43,8 +49,7 @@ class Storage:
             self._exchanges[exchange] = []
 
     async def add_message_to_queue(self, queue: str, message: Message) -> None:
-        if queue not in self._queues:
-            self._queues[queue] = Queue()
+        await self.declare_queue(queue)
         await self._queues[queue].put(message)
         self._history[message.id] = QueuedMessage(message, queue)
 

--- a/amqp_mock/amqp_server/_amqp_connection.py
+++ b/amqp_mock/amqp_server/_amqp_connection.py
@@ -33,10 +33,15 @@ class AmqpConnection:
         self._incoming_message: Union[Message, None] = None
         self._delivery_tag = 0
         self._on_consume = on_consume
+        self._on_bind: Optional[Callable[[str, str, str], Awaitable[None]]] = None
         self._on_publish: Optional[Callable[[Message], Awaitable[None]]] = None
         self._on_ack: Optional[Callable[[str], Awaitable[None]]] = None
         self._on_nack: Optional[Callable[[str], Awaitable[None]]] = None
         self._on_close: Optional[Callable[['AmqpConnection'], Awaitable[None]]] = None
+
+    def on_bind(self, callback: Callable[[str, str, str], Awaitable[None]]) -> 'AmqpConnection':
+        self._on_bind = callback
+        return self
 
     def on_publish(self, callback: Callable[[Message], Awaitable[None]]) -> 'AmqpConnection':
         self._on_publish = callback
@@ -199,6 +204,9 @@ class AmqpConnection:
         return await self._send_frame(channel_id, frame_out)
 
     async def _send_queue_bind_ok(self, channel_id: int, frame_in: spec.Queue.Bind) -> None:
+        if self._on_bind:
+            await self._on_bind(frame_in.queue, frame_in.exchange, frame_in.routing_key)
+
         frame_out = spec.Queue.BindOk()
         return await self._send_frame(channel_id, frame_out)
 

--- a/amqp_mock/amqp_server/_amqp_connection.py
+++ b/amqp_mock/amqp_server/_amqp_connection.py
@@ -34,6 +34,7 @@ class AmqpConnection:
         self._delivery_tag = 0
         self._on_consume = on_consume
         self._on_bind: Optional[Callable[[str, str, str], Awaitable[None]]] = None
+        self._on_declare_queue: Optional[Callable[[str], Awaitable[None]]] = None
         self._on_publish: Optional[Callable[[Message], Awaitable[None]]] = None
         self._on_ack: Optional[Callable[[str], Awaitable[None]]] = None
         self._on_nack: Optional[Callable[[str], Awaitable[None]]] = None
@@ -41,6 +42,10 @@ class AmqpConnection:
 
     def on_bind(self, callback: Callable[[str, str, str], Awaitable[None]]) -> 'AmqpConnection':
         self._on_bind = callback
+        return self
+
+    def on_declare_queue(self, callback: Callable[[str], Awaitable[None]]) -> 'AmqpConnection':
+        self._on_declare_queue = callback
         return self
 
     def on_publish(self, callback: Callable[[Message], Awaitable[None]]) -> 'AmqpConnection':
@@ -195,6 +200,9 @@ class AmqpConnection:
         await self._send_frame(channel_id, frame_out)
 
     async def _send_queue_declare_ok(self, channel_id: int, frame_in: spec.Queue.Declare) -> None:
+        if self._on_declare_queue:
+            await self._on_declare_queue(frame_in.queue)
+
         frame_out = spec.Queue.DeclareOk(queue=frame_in.queue, message_count=0, consumer_count=0)
         return await self._send_frame(channel_id, frame_out)
 

--- a/amqp_mock/amqp_server/_amqp_server.py
+++ b/amqp_mock/amqp_server/_amqp_server.py
@@ -51,6 +51,9 @@ class AmqpServer:
     async def _on_bind(self, queue: str, exchange: str, routing_key: str) -> None:
         await self._storage.bind_queue_to_exchange(queue, exchange, routing_key)
 
+    async def _on_declare_queue(self, queue: str):
+        await self._storage.declare_queue(queue)
+
     async def _on_publish(self, message: Message) -> None:
         try:
             message.value = json.loads(message.value.decode())
@@ -76,6 +79,7 @@ class AmqpServer:
         connection = AmqpConnection(reader, writer, self._on_consume, self._server_properties)
         connection.on_publish(self._on_publish) \
                   .on_bind(self._on_bind) \
+                  .on_declare_queue(self._on_declare_queue) \
                   .on_ack(self._on_ack) \
                   .on_nack(self._on_nack) \
                   .on_close(self._on_close)

--- a/amqp_mock/amqp_server/_amqp_server.py
+++ b/amqp_mock/amqp_server/_amqp_server.py
@@ -48,6 +48,9 @@ class AmqpServer:
     def port(self, value: int) -> None:
         self._port = value
 
+    async def _on_bind(self, queue: str, exchange: str, routing_key: str) -> None:
+        await self._storage.bind_queue_to_exchange(queue, exchange, routing_key)
+
     async def _on_publish(self, message: Message) -> None:
         try:
             message.value = json.loads(message.value.decode())
@@ -72,6 +75,7 @@ class AmqpServer:
     def __call__(self, reader: StreamReader, writer: StreamWriter) -> AmqpConnection:
         connection = AmqpConnection(reader, writer, self._on_consume, self._server_properties)
         connection.on_publish(self._on_publish) \
+                  .on_bind(self._on_bind) \
                   .on_ack(self._on_ack) \
                   .on_nack(self._on_nack) \
                   .on_close(self._on_close)

--- a/tests/_test_utils/amqp_client.py
+++ b/tests/_test_utils/amqp_client.py
@@ -42,8 +42,9 @@ class AmqpClient:
         res = await self._channel.queue_bind(queue_name, exchange_name, routing_key="")
         assert isinstance(res, spec.Queue.BindOk)
 
-    async def publish(self, message: bytes, exchange_name: str) -> None:
-        res = await self._channel.basic_publish(message, exchange=exchange_name, routing_key="")
+    async def publish(self, message: bytes, exchange_name: str, routing_key: str = "") -> None:
+        res = await self._channel.basic_publish(message, exchange=exchange_name,
+                                                routing_key=routing_key)
         assert isinstance(res, spec.Basic.Ack)
 
     async def _on_message(self, message: DeliveredMessage) -> None:

--- a/tests/test_publish_message.py
+++ b/tests/test_publish_message.py
@@ -102,6 +102,23 @@ async def test_publish_message_specific_queue(*, mock_server, mock_client, amqp_
 
 
 @pytest.mark.asyncio
+async def test_publish_to_exchange_with_bound_queue(*, mock_server, amqp_client):
+    with given:
+        exchange = "test_exchange"
+        queue = "test_queue"
+        message = b"text"
+
+    with when:
+        await amqp_client.queue_bind(queue, exchange)
+        await amqp_client.publish(message, exchange)
+        await amqp_client.consume(queue)
+
+    with then:
+        messages = await amqp_client.wait_for(message_count=1)
+        assert len(messages) == 1
+
+
+@pytest.mark.asyncio
 async def test_publish_no_messages(*, mock_server, amqp_client):
     with given:
         queue = "test_queue1"

--- a/tests/test_publish_message.py
+++ b/tests/test_publish_message.py
@@ -102,6 +102,27 @@ async def test_publish_message_specific_queue(*, mock_server, mock_client, amqp_
 
 
 @pytest.mark.asyncio
+async def test_publish_to_default_exchange(*, mock_server, mock_client, amqp_client):
+    with given:
+        exchange = ""
+        queue = "test_queue"
+        message = {"value": "text"}
+
+    with when:
+        await amqp_client.declare_queue(queue)
+        await amqp_client.publish(to_binary(message), exchange, routing_key=queue)
+        await amqp_client.consume(queue)
+
+    with then:
+        messages = await amqp_client.wait_for(message_count=1)
+        assert len(messages) == 1
+        assert messages[0].body == to_binary(message)
+        messages = await mock_client.get_exchange_messages("")
+        assert len(messages) == 1
+        assert messages[0].value == message
+
+
+@pytest.mark.asyncio
 async def test_publish_to_exchange_with_bound_queue(*, mock_server, amqp_client):
     with given:
         exchange = "test_exchange"


### PR DESCRIPTION
Previously, publishing a message to an exchange (either through the mock
client, or through a "real" client connected to the mock server) would
not result in that message being added to any queues bound to the
exchange.  Testing queues and exchanges were totally separate.  E.g. for
the same effect you would have to have a "real" client publish to an
exchange, and have the mock client publish to an associated queue.

This automatically adds any messages published to an exchange to any
queues bound to that exchange (this assumes direct routing--fanout
will be added in a follow-up).