### PR TITLE
Allow bytes (non-json) message values

### DIFF
--- a/amqp_mock/_message.py
+++ b/amqp_mock/_message.py
@@ -29,7 +29,7 @@ class Message:
     def to_dict(self) -> Dict[str, Any]:
         return {
             "id": self.id,
-            "value": self.value,
+            "value": str(self.value) if isinstance(self.value, bytes) else self.value,
             "exchange": self.exchange,
             "routing_key": self.routing_key,
             "properties": self.properties,

--- a/amqp_mock/amqp_server/_amqp_connection.py
+++ b/amqp_mock/amqp_server/_amqp_connection.py
@@ -133,7 +133,10 @@ class AmqpConnection:
             )
             await self._send_frame(channel_id, frame_out)
 
-            encoded = json.dumps(message.value).encode()
+            if isinstance(message.value, bytes):
+                encoded = message.value
+            else:
+                encoded = json.dumps(message.value).encode()
             properties = commands.Basic.Properties(**(message.properties or {}))
             header = ContentHeader(body_size=len(encoded), properties=properties)
             body = ContentBody(encoded)

--- a/amqp_mock/amqp_server/_amqp_server.py
+++ b/amqp_mock/amqp_server/_amqp_server.py
@@ -58,7 +58,7 @@ class AmqpServer:
         try:
             message.value = json.loads(message.value.decode())
         except (TypeError, ValueError):
-            message.value = str(message.value)
+            pass
         await self._storage.add_message_to_exchange(message.exchange, message)
 
     async def _on_consume(self, queue_name: str) -> AsyncGenerator[Message, None]:


### PR DESCRIPTION
In my use-case, message values are serialized protobuf messages which cannot be interpreted as JSON. As such, the line `message.value = str(message.value)` was turning a serialized message like `b'test'` into its string representation `"b'test'"`. Upon consumption, `json.dumps(message.value).encode()` was further transforming the message, sending the bytes object `b'"b'test'"'` to the consumer, and as such the consumer could not parse the intended protobuf message at all.

This PR keeps the bytes object as-is if it couldn't be parsed as JSON. It only transforms it into its string representation in `to_dict()` if necessary, since this seems to be only place where it needs to be usable as JSON.