### PR TITLE
fix: wheel includes tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     python_requires=">=3.8.0",
     url="https://github.com/tsv1/amqp-mock",
     license="Apache-2.0",
-    packages=find_packages(exclude=("tests",)),
+    packages=find_packages(exclude=("tests*",)),
     package_data={"amqp_mock": ["py.typed"]},
     install_requires=find_required(),
     tests_require=find_dev_required(),


### PR DESCRIPTION
Currently the wheels include `tests`. (see attached log 1)

This can cause problems with buildsystems like bazel.

Based on the configuration in [setup.py](https://github.com/tsv1/amqp-mock/blob/bb4b9e921d8e2f6c880c5bb02d1650de3a5bc8fc/setup.py#L25) I'm assuming this is unintended behavior.

This PR excludes them from the build. (see attached log 2)


log 1:
```sh
$ wget https://files.pythonhosted.org/packages/90/80/bebe9a4e68cf23aa4ae70bced2a36186a5fc74ff49
df4eaa70b9be163dc1/amqp_mock-0.6.1-py3-none-any.whl
$ unzip -t amqp_mock-0.6.1-py3-none-any.whl | grep -e tests
    testing: tests/_test_utils/__init__.py   OK
    testing: tests/_test_utils/amqp_client.py   OK
    testing: tests/_test_utils/fixtures.py   OK
    testing: tests/_test_utils/helpers.py   OK
    testing: tests/_test_utils/schemas.py   OK
    testing: tests/_test_utils/steps.py   OK
```

log 2:
```sh
$ make build
$ unzip -t dist/amqp_mock-0.6.1-py3-none-any.whl | grep -e tests
```